### PR TITLE
Log live Cassandra query and execute args 

### DIFF
--- a/cassandra_cql.go
+++ b/cassandra_cql.go
@@ -285,7 +285,7 @@ func (p *cassandra_cql_Parser) report(req, resp *cassandra_cql_frame) {
 		// read consistency
 		payload, _, err = readShort(payload)
 		if err != nil {
-			fmt.Printf("read consistency err: %v", err)
+			fmt.Printf("read consistency err: %v\n", err)
 			return
 		}
 
@@ -296,7 +296,7 @@ func (p *cassandra_cql_Parser) report(req, resp *cassandra_cql_frame) {
 			payload, _, err = readByte(payload)
 		}
 		if err != nil {
-			fmt.Printf("read flags err: %v", err)
+			fmt.Printf("read flags err: %v\n", err)
 			return
 		}
 
@@ -304,7 +304,7 @@ func (p *cassandra_cql_Parser) report(req, resp *cassandra_cql_frame) {
 		var args uint16
 		payload, args, err = readShort(payload)
 		if err != nil {
-			fmt.Printf("read num args err: %v", err)
+			fmt.Printf("read num args err: %v\n", err)
 			return
 		}
 
@@ -313,7 +313,7 @@ func (p *cassandra_cql_Parser) report(req, resp *cassandra_cql_frame) {
 			var numBytes int32
 			payload, numBytes, err = readInt(payload)
 			if err != nil {
-				fmt.Printf("read arg %d length err: %v", i, err)
+				fmt.Printf("read arg %d length err: %v\n", i, err)
 				return
 			}
 			switch {
@@ -327,7 +327,7 @@ func (p *cassandra_cql_Parser) report(req, resp *cassandra_cql_frame) {
 				var bytes []byte
 				payload, bytes, err = readBytes(payload, int(numBytes))
 				if err != nil {
-					fmt.Printf("read arg %d value err: %v", i, err)
+					fmt.Printf("read arg %d value err: %v\n", i, err)
 					return
 				}
 				buf.WriteString(fmt.Sprintf("\"%x\"", bytes))

--- a/cassandra_cql.go
+++ b/cassandra_cql.go
@@ -253,12 +253,12 @@ func (p *cassandra_cql_Parser) report(req, resp *cassandra_cql_frame) {
 	}
 	if req.opcode == cmd_PREPARE && req.data != nil {
 		if qcql, ok := read_longstring(req.data); ok {
+			data = data[4+len(qcql):]
 			if resp.data != nil && len(resp.data) >= 2 {
 				qcql = strings.Replace(qcql, "\n", " ", -1)
 				qcql = strings.Replace(qcql, "\r", " ", -1)
 				cql = &qcql
 				p.factory.parsed[binary.BigEndian.Uint16(resp.data)] = *cql
-				data = data[4+len(qcql):]
 			}
 		}
 	}
@@ -282,6 +282,8 @@ func (p *cassandra_cql_Parser) report(req, resp *cassandra_cql_frame) {
 			err     error
 		)
 
+		fmt.Printf("proto version: %d\n", int(req.version))
+
 		// read consistency
 		payload, _, err = readShort(payload)
 		if err != nil {
@@ -290,11 +292,11 @@ func (p *cassandra_cql_Parser) report(req, resp *cassandra_cql_frame) {
 		}
 
 		// read flags
-		if req.version > 4 {
-			payload, _, err = readUint(payload)
-		} else {
-			payload, _, err = readByte(payload)
-		}
+		// if req.version > 4 {
+		payload, _, err = readUint(payload)
+		// } else {
+		// 	payload, _, err = readByte(payload)
+		// }
 		if err != nil {
 			fmt.Printf("read flags err: %v\n", err)
 			return

--- a/cassandra_cql.go
+++ b/cassandra_cql.go
@@ -299,7 +299,8 @@ func (p *cassandra_cql_Parser) report(req, resp *cassandra_cql_frame) {
 	if req.opcode == cmd_QUERY || req.opcode == cmd_EXECUTE {
 		var buf strings.Builder
 
-		buf.WriteString(fmt.Sprintf("{\"cql\": \"%s\", \"args\": [", *cql))
+		now := time.Now().UnixNano()
+		buf.WriteString(fmt.Sprintf("{\"unixnanos\": %d, \"cql\": \"%s\", \"args\": [", now, *cql))
 
 		if *debug_cql_req {
 			fmt.Printf("proto version: %d\n", int(req.version))

--- a/cassandra_cql.go
+++ b/cassandra_cql.go
@@ -599,16 +599,21 @@ func init() {
 	cassProt.interpFactory = factory
 	RegisterTCPProtocol(cassProt)
 
-	if f := *capture_cql_file; f != "" {
-		fd, err := os.Create(f)
-		if err != nil {
-			log.Printf("failed to open capture file: file=%s, err=%v\n", f, err)
-			return
-		}
-		captureFile.Lock()
-		captureFile.fd = fd
-		captureFile.Unlock()
+	f := *capture_cql_file
+	if f == "" {
+		log.Println("no capture file specified")
+		return
 	}
+
+	log.Println("opening capture file: %v\n", f)
+	fd, err := os.Create(f)
+	if err != nil {
+		log.Printf("failed to open capture file: file=%s, err=%v\n", f, err)
+		return
+	}
+	captureFile.Lock()
+	captureFile.fd = fd
+	captureFile.Unlock()
 }
 
 type CassandraQuery struct {

--- a/cassandra_cql.go
+++ b/cassandra_cql.go
@@ -14,11 +14,8 @@ import (
 	"github.com/golang/snappy"
 )
 
-const (
-	DEFAULT_CQL = "cql_unknown"
-)
-
 var (
+	DEFAULT_CQL      = "cql_unknown"
 	debug_cql        = flag.Bool("debug_cql", false, "Debug cassandra cql reassembly")
 	debug_cql_req    = flag.Bool("debug_cql_req", false, "Debug cassandra cql request reassembly")
 	capture_cql_file = flag.String("capture_cql_file", "", "Capture cassandra cql traffic and encode to file")

--- a/cassandra_cql.go
+++ b/cassandra_cql.go
@@ -14,7 +14,20 @@ import (
 	"github.com/golang/snappy"
 )
 
-var debug_cql = flag.Bool("debug_cql", false, "Debug cassandra cql reassembly")
+const (
+	DEFAULT_CQL = "cql_unknown"
+)
+
+var (
+	debug_cql        = flag.Bool("debug_cql", false, "Debug cassandra cql reassembly")
+	debug_cql_req    = flag.Bool("debug_cql_req", false, "Debug cassandra cql request reassembly")
+	capture_cql_file = flag.String("capture_cql_file", "", "Capture cassandra cql traffic and encode to file")
+
+	captureFile = &struct {
+		sync.Mutex
+		fd *os.File
+	}{}
+)
 
 const (
 	retainedPayloadSize int = 512
@@ -245,17 +258,6 @@ func read_longstring(data []byte) (out string, ok bool) {
 
 	return string(bytes), true
 }
-
-var DEFAULT_CQL string = "cql_unknown"
-
-var (
-	capture_cql_file = flag.String("capture_cql_file", "", "Capture cassandra cql traffic and encode to file")
-	debug_cql_req    = flag.Bool("debug_cql_req", false, "Debug cassandra cql request reassembly")
-	captureFile      = &struct {
-		sync.Mutex
-		fd *os.File
-	}{}
-)
 
 var protoBufPool = sync.Pool{
 	New: func() interface{} {

--- a/cassandra_cql.go
+++ b/cassandra_cql.go
@@ -260,7 +260,9 @@ var protoBufPool = sync.Pool{
 }
 
 func getProtoBuf() *proto.Buffer {
-	return protoBufPool.Get().(*proto.Buffer)
+	buf := protoBufPool.Get().(*proto.Buffer)
+	buf.Reset()
+	return buf
 }
 
 func putProtoBuf(b *proto.Buffer) {

--- a/cassandra_cql_test.go
+++ b/cassandra_cql_test.go
@@ -1,0 +1,58 @@
+package wirelatency
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+)
+
+func TestCassandraQuery(t *testing.T) {
+	f := &CassandraQuery{
+		Version:    1,
+		ReceivedAt: time.Now(),
+		CQL:        "foo",
+		Args:       [][]byte{[]byte("bar"), []byte("baz")},
+	}
+
+	buf := proto.NewBuffer(nil)
+	n := 42
+	for i := 0; i < n; i++ {
+		err := f.Encode(buf)
+		if err != nil {
+			t.Fatalf("failed to encode buffer: %v", err)
+		}
+	}
+
+	// New buffer with the contents of the current buffer
+	buf = proto.NewBuffer(buf.Bytes())
+	for i := 0; i < n; i++ {
+		d := &CassandraQuery{}
+		err := d.Decode(buf)
+		if err != nil {
+			t.Fatalf("failed to decode buffer: %v", err)
+		}
+
+		if d.Version != f.Version {
+			t.Fatalf("invalid version: %v", d.Version)
+		}
+
+		if !d.ReceivedAt.Equal(f.ReceivedAt) {
+			t.Fatalf("invalid received at: %v", d.ReceivedAt.String())
+		}
+
+		if d.CQL != f.CQL {
+			t.Fatalf("invalid cql: %v", d.CQL)
+		}
+
+		if len(d.Args) != len(f.Args) {
+			t.Fatalf("invalid len args: %v", len(d.Args))
+		}
+		for i, arg := range d.Args {
+			if !bytes.Equal(arg, f.Args[i]) {
+				t.Fatalf("invalid arg at index %d: %v", i, arg)
+			}
+		}
+	}
+}

--- a/cassandra_cql_test.go
+++ b/cassandra_cql_test.go
@@ -33,8 +33,8 @@ func TestCassandraQuery(t *testing.T) {
 
 		bytes := buf.Bytes()
 
-		binary.LittleEndian.PutUint32(lengthBuf[:], uint32(len(bytes)))
-		if _, err := output.Write(lengthBuf[:]); err != nil {
+		binary.LittleEndian.PutUint32(lengthBuf, uint32(len(bytes)))
+		if _, err := output.Write(lengthBuf); err != nil {
 			t.Fatalf("failed to write output size: %v", err)
 		}
 
@@ -50,12 +50,12 @@ func TestCassandraQuery(t *testing.T) {
 		d := &CassandraQuery{}
 
 		// Read the size of the message
-		_, err := io.ReadFull(reader, lengthBuf[:])
+		_, err := io.ReadFull(reader, lengthBuf)
 		if err != nil {
 			t.Fatalf("failed to read length: %v", err)
 		}
 
-		size := binary.LittleEndian.Uint32(lengthBuf[:])
+		size := binary.LittleEndian.Uint32(lengthBuf)
 		if cap(reuseableBuf) < int(size) {
 			reuseableBuf = make([]byte, size)
 		} else {

--- a/http.go
+++ b/http.go
@@ -3,7 +3,6 @@ package wirelatency
 import (
 	"encoding/json"
 	"flag"
-	"github.com/google/gopacket/tcpassembly/tcpreader"
 	"io"
 	"io/ioutil"
 	"log"
@@ -12,6 +11,8 @@ import (
 	"regexp"
 	"sync"
 	"time"
+
+	"github.com/google/gopacket/tcpassembly/tcpreader"
 )
 
 var debug_wl_http = flag.Bool("debug_wl_http", false, "Debug wirelatency HTTP decoding")
@@ -70,7 +71,7 @@ func (p *httpParser) ManageIn(stream *tcpTwoWayStream) {
 	defer func() {
 		if r := recover(); r != nil {
 			if *debug_wl_http {
-				log.Println("[RECOVERY] (http/ManageIn): %v", r)
+				log.Printf("[RECOVERY] (http/ManageIn): %v\n", r)
 			}
 		}
 	}()
@@ -109,7 +110,7 @@ func (p *httpParser) ManageIn(stream *tcpTwoWayStream) {
 			nbytes, derr := tcpreader.DiscardBytesToFirstError(req.Body)
 			if derr != nil && derr != io.EOF {
 				if *debug_wl_http {
-					log.Println("[DEBUG] error reading request body: %v", derr)
+					log.Printf("[DEBUG] error reading request body: %v\n", derr)
 				}
 				return
 			}
@@ -137,7 +138,7 @@ func (p *httpParser) ManageOut(stream *tcpTwoWayStream) {
 	defer func() {
 		if r := recover(); r != nil {
 			if *debug_wl_http {
-				log.Println("[RECOVERY] (http/ManageOut): %v", r)
+				log.Printf("[RECOVERY] (http/ManageOut): %v\n", r)
 			}
 		}
 	}()
@@ -171,7 +172,7 @@ func (p *httpParser) ManageOut(stream *tcpTwoWayStream) {
 			nbytes, derr := tcpreader.DiscardBytesToFirstError(resp.Body)
 			if derr != nil && derr != io.EOF {
 				if *debug_wl_http {
-					log.Println("[DEBUG] error reading http response body: %v", derr)
+					log.Printf("[DEBUG] error reading http response body: %v\n", derr)
 				}
 				return
 			}


### PR DESCRIPTION
This adds the ability to log Cassandra queries (both prepared and unprepared) and prints them out and the args out as a JSON log.